### PR TITLE
security: measure against CVE-2021-44228

### DIFF
--- a/service/elasticsearch/latest.yml
+++ b/service/elasticsearch/latest.yml
@@ -5,7 +5,7 @@ service:
     node.name: riptide
     cluster.name: riptide-cluster
     discovery.type: "single-node"
-    ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+    ES_JAVA_OPTS: "-Xms512m -Xmx512m -Dlog4j2.formatMsgNoLookups=true"
   port: 9200
   additional_volumes:
     data:


### PR DESCRIPTION
M2-issue: https://github.com/magento/magento2/issues/34796

Due to magento2 dependencies not currently possible, but ideal way would be to update elasticsearch to either

- elasticsearch:7.16.1
- elasticsearch:6.8.21

What is possible though is to set the java virtual machine option for elasticsearch.