### PR TITLE
Change include order

### DIFF
--- a/app/craft/assets/default.conf
+++ b/app/craft/assets/default.conf
@@ -11,6 +11,9 @@ server {
     # index.php
     index       index.php;
 
+    # Additional project config files
+    include craftcms/x-*.conf;
+
     # index.php fallback
     location / {
         try_files $uri $uri/ /index.php?$query_string;
@@ -23,9 +26,6 @@ server {
     location ~ \.php$ {
         include craftcms/php_fastcgi.conf;
     }
-
-    # Additional project config files
-    include craftcms/x-*.conf;
 
     # Allow fpm ping and status from localhost
     location ~ ^/(fpm-status|fpm-ping)$ {


### PR DESCRIPTION
This will prevent override custom configs by `location \`. Otherwise this would be ignored:

```
location ~ "^/(.+)\.(\d+)\.(bmp|css|cur|gif|ico|jpe?g|js|png|svgz?|webp|webmanifest)$" {
    try_files $uri /$1.$3$is_args$args;
}
```