### PR TITLE
elasticsearch: optimize default setup

### DIFF
--- a/service/elasticsearch/assets/elasticsearch.yml
+++ b/service/elasticsearch/assets/elasticsearch.yml
@@ -1,3 +1,6 @@
 cluster.name: "docker-cluster"
 network.host: 0.0.0.0
 discovery.type: single-node
+
+# only for development
+cluster.routing.allocation.disk.threshold_enabled: false

--- a/service/elasticsearch/latest.yml
+++ b/service/elasticsearch/latest.yml
@@ -5,7 +5,7 @@ service:
     node.name: riptide
     cluster.name: riptide-cluster
     discovery.type: "single-node"
-    ES_JAVA_OPTS: "-Xms512m -Xmx512m -Dlog4j2.formatMsgNoLookups=true"
+    ES_JAVA_OPTS: "-Xms64m -Xmx200m -Dlog4j2.formatMsgNoLookups=true"
   port: 9200
   additional_volumes:
     data:


### PR DESCRIPTION
* reduce memory footprint of about ~1G
* disable threshold that switches indices to read-only mode if hit
  the default of 10% free disc space is ridiculous on modern developer machines
  eg. 50GB free space on modern ssds (512+ GB) is more than enough to run elasticsearch