### PR TITLE
Shopify

### DIFF
--- a/app/shopify/README.rst
+++ b/app/shopify/README.rst
@@ -1,0 +1,57 @@
+Shopify
+=======
+
+`Shopify App`_ App for Shopify E-commerce software.
+
+.. _`Shopify App`: https://shopify.dev/apps
+
+..  contents:: Index
+    :depth: 3
+
+``/app/base``
+-------------
+
+Base for Shopify projects.
+
+Services
+~~~~~~~~
+
+Shopify
++++++++
+
+`Shopify Service`_ Service for Shopify commands
+
+.. _`Shopify Service`: /service/shopify
+
+Commands
+~~~~~~~~
+
+shopify
++++++++
+
+`Shopify Command`_ Shopify CLI command
+
+.. _`Shopify Command`: /command/shopify
+
+npm
++++
+
+`npm`_ Node.js package manager
+
+.. _`npm`: /command/npm
+
+
+yarn
+++++
+
+`yarn`_ Node.js package manager
+
+.. _`yarn`: /command/yarn
+
+
+node
+++++
+
+`node`_ JavaScript runtime
+
+.. _`node`: /command/node

--- a/app/shopify/README.rst
+++ b/app/shopify/README.rst
@@ -4,12 +4,7 @@ Shopify
 `Shopify App`_ App for Shopify E-commerce software.
 
 Get started quickly (after ``riptide setup``):
-
-``get-makefile > Makefile``
-
-``get-readme > README.md``
-
-Check the new ``README.md`` for further steps.
+Run ``riptide cmd setup``, then check ``shopify-app.md`` for further steps.
 
 .. _`Shopify App`: https://shopify.dev/apps
 

--- a/app/shopify/README.rst
+++ b/app/shopify/README.rst
@@ -3,6 +3,14 @@ Shopify
 
 `Shopify App`_ App for Shopify E-commerce software.
 
+Get started quickly (after ``riptide setup``):
+
+``get-makefile > Makefile``
+
+``get-readme > README.md``
+
+Check the new ``README.md`` for further steps.
+
 .. _`Shopify App`: https://shopify.dev/apps
 
 ..  contents:: Index
@@ -19,7 +27,7 @@ Services
 Shopify
 +++++++
 
-`Shopify Service`_ Service for Shopify commands
+`Shopify Service`_ Service for Shopify commands.
 
 .. _`Shopify Service`: /service/shopify
 
@@ -29,14 +37,14 @@ Commands
 shopify
 +++++++
 
-`Shopify Command`_ Shopify CLI command
+`Shopify Command`_ Shopify CLI command.
 
 .. _`Shopify Command`: /command/shopify
 
 npm
 +++
 
-`npm`_ Node.js package manager
+`npm`_ Node.js package manager.
 
 .. _`npm`: /command/npm
 
@@ -44,7 +52,7 @@ npm
 yarn
 ++++
 
-`yarn`_ Node.js package manager
+`yarn`_ Node.js package manager.
 
 .. _`yarn`: /command/yarn
 
@@ -52,6 +60,24 @@ yarn
 node
 ++++
 
-`node`_ JavaScript runtime
+`node`_ JavaScript runtime.
 
 .. _`node`: /command/node
+
+
+get-makefile
+++++
+
+Get the Makefile_ used to setup your Shopify project.
+Use it like ``get-makefile > Makefile``.
+
+.. _Makefile: https://github.com/theCapypara/riptide-docker-images/blob/master/shopify/Makefile
+
+
+get-readme
+++++
+
+Get the README_ containing notes how to develop your Shopify app with Riptide.
+Use it like ``get-readme > README.md``.
+
+.. _README: https://github.com/theCapypara/riptide-docker-images/blob/master/shopify/riptide.md

--- a/app/shopify/base.yml
+++ b/app/shopify/base.yml
@@ -1,0 +1,24 @@
+app:
+  name: shopify
+
+  notices:
+    usage: >-
+      Don't start the Shopify service, it will stop automatically. Use the Riptide commands, like described in the README.md.
+      The commands won't work properly, if you have the service running.
+      If you really want the container to keep running, e.g. to jump into it, use "riptide start -c keep_running".
+    installation: >-
+      See README.md for setup steps.
+
+  services:
+    shopify:
+      $ref: /service/shopify/base
+
+  commands:
+    shopify:
+      $ref: /command/shopify/in-shopify-service
+    npm:
+      $ref: /command/npm/in-shopify-service
+    yarn:
+      $ref: /command/yarn/in-shopify-service
+    node:
+      $ref: /command/node/in-shopify-service

--- a/app/shopify/base.yml
+++ b/app/shopify/base.yml
@@ -22,9 +22,6 @@ app:
       $ref: /command/yarn/in-shopify-service
     node:
       $ref: /command/node/in-shopify-service
-    get-makefile:
-      command: cat /assets/Makefile
-      in_service_with_role: shopify
-    get-readme:
-      command: cat /assets/riptide.md
+    setup:
+      command: echo Setup done! Please check shopify-app.md.
       in_service_with_role: shopify

--- a/app/shopify/base.yml
+++ b/app/shopify/base.yml
@@ -3,11 +3,11 @@ app:
 
   notices:
     usage: >-
-      Don't start the Shopify service, it will stop automatically. Use the Riptide commands, like described in the README.md.
+      Don't start the Shopify service, it will stop automatically. Use the Riptide commands, like described in the shopify-app.md.
       The commands won't work properly, if you have the service running.
       If you really want the container to keep running, e.g. to jump into it, use "riptide start -c keep_running".
     installation: >-
-      See README.md for setup steps.
+      Run riptide cmd setup, then check shopify-app.md for further steps.
 
   services:
     shopify:

--- a/app/shopify/base.yml
+++ b/app/shopify/base.yml
@@ -22,3 +22,9 @@ app:
       $ref: /command/yarn/in-shopify-service
     node:
       $ref: /command/node/in-shopify-service
+    get-makefile:
+      command: cat /assets/Makefile
+      in_service_with_role: shopify
+    get-readme:
+      command: cat /assets/riptide.md
+      in_service_with_role: shopify

--- a/command/node/README.rst
+++ b/command/node/README.rst
@@ -24,3 +24,15 @@ Different Node.jS versions. Available versions:
 - 12
 
 Other versions can be used by changing the version of the image.
+
+``/command/node/in-shopify-service``
+------------------------------------
+
+Running ``node`` command in the service with role ``shopify``.
+
+Role Requirements
+~~~~~~~~~~~~~~~~~
+
+**Role**: ``shopify``
+
+This command requires another service that has the role ``shopify`` set.

--- a/command/node/in-shopify-service.yml
+++ b/command/node/in-shopify-service.yml
@@ -1,0 +1,4 @@
+command:
+  command: bash -c "node \"\$@\"" --
+  use_host_network: true
+  in_service_with_role: shopify

--- a/command/npm/README.rst
+++ b/command/npm/README.rst
@@ -12,7 +12,7 @@ require access to the npm cache.
     :depth: 2
 
 ``/command/npm/base``
-----------------------
+---------------------
 
 Latest NPM version with the latest Node.js version.
 
@@ -40,3 +40,15 @@ Latest NPM with different Node.js versions. Avaiable Node.js versions:
 - 10
 - 11
 - 12
+
+``/command/npm/in-shopify-service``
+-----------------------------------
+
+Running ``npm`` command in the service with role ``shopify``.
+
+Role Requirements
+~~~~~~~~~~~~~~~~~
+
+**Role**: ``shopify``
+
+This command requires another service that has the role ``shopify`` set.

--- a/command/npm/in-shopify-service.yml
+++ b/command/npm/in-shopify-service.yml
@@ -1,0 +1,4 @@
+command:
+  command: bash -c "npm \"\$@\"" --
+  use_host_network: true
+  in_service_with_role: shopify

--- a/command/shopify/README.rst
+++ b/command/shopify/README.rst
@@ -1,0 +1,21 @@
+Shopify
+=======
+
+`Shopify CLI`_ Command line interface for Shopify E-commerce software.
+
+.. _`Shopify CLI`: https://shopify.dev/apps/tools/cli
+
+..  contents:: Index
+    :depth: 2
+
+``/command/shopify/in-shopify-service``
+---------------------------------------
+
+Running ``shopify`` command in the service with role ``shopify``.
+
+Role Requirements
+~~~~~~~~~~~~~~~~~
+
+**Role**: ``shopify``
+
+This command requires another service that has the role ``shopify`` set.

--- a/command/shopify/in-shopify-service.yml
+++ b/command/shopify/in-shopify-service.yml
@@ -1,0 +1,4 @@
+command:
+  command: bash -c "cd /src && ./node_modules/.bin/shopify \"\$@\"" --
+  use_host_network: true
+  in_service_with_role: shopify

--- a/command/yarn/README.rst
+++ b/command/yarn/README.rst
@@ -40,3 +40,15 @@ Latest Yarn with different Node.js versions. Avaiable Node.js versions:
 - 10
 - 11
 - 12
+
+``/command/yarn/in-shopify-service``
+------------------------------------
+
+Running ``yarn`` command in the service with role ``shopify``.
+
+Role Requirements
+~~~~~~~~~~~~~~~~~
+
+**Role**: ``shopify``
+
+This command requires another service that has the role ``shopify`` set.

--- a/command/yarn/in-shopify-service.yml
+++ b/command/yarn/in-shopify-service.yml
@@ -1,0 +1,4 @@
+command:
+  command: bash -c "yarn \"\$@\"" --
+  use_host_network: true
+  in_service_with_role: shopify

--- a/service/shopify/README.rst
+++ b/service/shopify/README.rst
@@ -1,0 +1,48 @@
+shopify
+=======
+
+Shopify Service for Shopify E-commerce software app.
+
+..  contents:: Index
+    :depth: 2
+
+``/service/shopify/base``
+-------------------------
+
+**Accessible via Proxy?**: no
+
+**Runs as the user using Riptide?**: yes
+
+Base to run all Shopify related commands.
+
+Suggested Roles
+~~~~~~~~~~~~~~~
+
+**Has roles**: ``shopify``
+
+This service has the role ``shopify`` set and is a base for Shopify related commands.
+
+**Suggested roles**: ``src``, ``main``
+
+This service should have access to the source code of the application via the role ``src``.
+
+Additional volumes
+~~~~~~~~~~~~~~~~~~
+
++----------------+----------------+----------------------------------+----------------------------------+--------------------+
+| Name           | Source         | Source path                      | Target path                      | Description        |
++================+================+==================================+==================================+====================+
+| shopify_config | Home directory | ~/.config/shopify-cli-kit-nodejs | ~/.config/shopify-cli-kit-nodejs | Shopify CLI config |
++----------------+----------------+----------------------------------+----------------------------------+--------------------+
+| shopify_cache  | Home directory | ~/.cache/shopify-cli-nodejs      | ~/.cache/shopify-cli-nodejs      | Shopify CLI cache  |
++----------------+----------------+----------------------------------+----------------------------------+--------------------+
+| ngrok_config   | Home directory | ~/.config/ngrok                  | ~/.config/ngrok                  | ngrok config       |
++----------------+----------------+----------------------------------+----------------------------------+--------------------+
+| yarn_cache     | Home directory | ~/.cache/yarn                    | ~/.cache/yarn                    | yarn cache         |
++----------------+----------------+----------------------------------+----------------------------------+--------------------+
+| npm_cache      | Home directory | ~/.npm                           | ~/.npm                           | npm cache          |
++----------------+----------------+----------------------------------+----------------------------------+--------------------+
+| ssh            | Home directory | ~/.ssh                           | ~/.ssh                           | SSH keys           |
++----------------+----------------+----------------------------------+----------------------------------+--------------------+
+| tmp            | Home directory | '{{ get_tempdir() }}'            | /tmp                             | temporary files    |
++----------------+----------------+----------------------------------+----------------------------------+--------------------+

--- a/service/shopify/base.yml
+++ b/service/shopify/base.yml
@@ -1,0 +1,36 @@
+service:
+  image: riptidepy/shopify:latest
+  command:
+    default: 'sleep 3'
+    keep_running: '$(while true; do sleep 1; done)'
+  roles:
+    - main
+    - shopify
+    - src
+  additional_volumes:
+    shopify_config:
+      container: /home/riptide/.config/shopify-cli-kit-nodejs
+      host: ~/.config/shopify-cli-kit-nodejs
+    shopify_cache:
+      container: /home/riptide/.cache/shopify-cli-nodejs
+      host: ~/.cache/shopify-cli-nodejs
+    ngrok_config:
+      container: /home/riptide/.config/ngrok
+      host: ~/.config/ngrok
+    yarn_cache:
+      container: /home/riptide/.cache/yarn
+      host: ~/.cache/yarn
+    npm_cache:
+      container: /home/riptide/.npm
+      host: ~/.npm
+    ssh:
+      container: /home/riptide/.ssh
+      host: ~/.ssh
+      mode: ro
+    tmp:
+      container: /tmp/
+      host: '{{ get_tempdir() }}'
+  working_directory: .
+  logging:
+    stdout: true
+    stderr: true


### PR DESCRIPTION
Adding a Riptide app containing all tools you need to develop your Shopify app.
See also: https://github.com/theCapypara/riptide-docker-images/pull/1