### PR TITLE
[Magento2] Add multisite configuration options & Small fixes

### DIFF
--- a/app/magento2/assets/magento-nginx-entrypoint.conf
+++ b/app/magento2/assets/magento-nginx-entrypoint.conf
@@ -1,0 +1,20 @@
+# PHP entry point for main application
+location ~ ^/(index|get|static|errors/report|errors/404|errors/503|health_check)\.php$ {
+    try_files $uri =404;
+    fastcgi_pass   fastcgi_backend;
+    fastcgi_buffers 16 16k;
+    fastcgi_buffer_size 32k;
+
+    fastcgi_param  PHP_FLAG  "session.auto_start=off \n suhosin.session.cryptua=off";
+    fastcgi_param  PHP_VALUE "memory_limit=756M \n max_execution_time=18000";
+    fastcgi_read_timeout 600s;
+    fastcgi_connect_timeout 600s;
+
+    fastcgi_index  index.php;
+    fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
+    # START - Multisite customization
+    fastcgi_param MAGE_RUN_TYPE $MAGE_RUN_TYPE;
+    fastcgi_param MAGE_RUN_CODE $MAGE_RUN_CODE;
+    # END - Multisite customization
+    include        fastcgi_params;
+}

--- a/app/magento2/assets/magento-nginx-entrypoint.conf
+++ b/app/magento2/assets/magento-nginx-entrypoint.conf
@@ -1,3 +1,182 @@
+## This is taken from the Magento 2 sample config. Overwrite this file in projects if needed.
+
+# Modules can be loaded only at the very beginning of the Nginx config file, please move the line below to the main config file
+# load_module /etc/nginx/modules/ngx_http_image_filter_module.so;
+
+root $MAGE_ROOT/pub;
+
+index index.php;
+autoindex off;
+charset UTF-8;
+error_page 404 403 = /errors/404.php;
+#add_header "X-UA-Compatible" "IE=Edge";
+
+
+# Deny access to sensitive files
+location /.user.ini {
+    deny all;
+}
+
+# PHP entry point for setup application
+location ~* ^/setup($|/) {
+    root $MAGE_ROOT;
+    location ~ ^/setup/index.php {
+        fastcgi_pass   fastcgi_backend;
+
+        fastcgi_param  PHP_FLAG  "session.auto_start=off \n suhosin.session.cryptua=off";
+        fastcgi_param  PHP_VALUE "memory_limit=756M \n max_execution_time=600";
+        fastcgi_read_timeout 600s;
+        fastcgi_connect_timeout 600s;
+
+        fastcgi_index  index.php;
+        fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
+        include        fastcgi_params;
+    }
+
+    location ~ ^/setup/(?!pub/). {
+        deny all;
+    }
+
+    location ~ ^/setup/pub/ {
+        add_header X-Frame-Options "SAMEORIGIN";
+    }
+}
+
+# PHP entry point for update application
+location ~* ^/update($|/) {
+    root $MAGE_ROOT;
+
+    location ~ ^/update/index.php {
+        fastcgi_split_path_info ^(/update/index.php)(/.+)$;
+        fastcgi_pass   fastcgi_backend;
+        fastcgi_index  index.php;
+        fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
+        fastcgi_param  PATH_INFO        $fastcgi_path_info;
+        include        fastcgi_params;
+    }
+
+    # Deny everything but index.php
+    location ~ ^/update/(?!pub/). {
+        deny all;
+    }
+
+    location ~ ^/update/pub/ {
+        add_header X-Frame-Options "SAMEORIGIN";
+    }
+}
+
+location / {
+    try_files $uri $uri/ /index.php$is_args$args;
+}
+
+location /pub/ {
+    location ~ ^/pub/media/(downloadable|customer|import|custom_options|theme_customization/.*\.xml) {
+        deny all;
+    }
+    alias $MAGE_ROOT/pub/;
+    add_header X-Frame-Options "SAMEORIGIN";
+}
+
+location /static/ {
+    # Uncomment the following line in production mode
+    # expires max;
+
+    # Remove signature of the static files that is used to overcome the browser cache
+    location ~ ^/static/version\d*/ {
+        rewrite ^/static/version\d*/(.*)$ /static/$1 last;
+    }
+
+    location ~* \.(ico|jpg|jpeg|png|gif|svg|svgz|webp|avif|avifs|js|css|eot|ttf|otf|woff|woff2|html|json|webmanifest)$ {
+        add_header Cache-Control "public";
+        add_header X-Frame-Options "SAMEORIGIN";
+        expires +1y;
+
+        if (!-f $request_filename) {
+            rewrite ^/static/(version\d*/)?(.*)$ /static.php?resource=$2 last;
+        }
+    }
+    location ~* \.(zip|gz|gzip|bz2|csv|xml)$ {
+        add_header Cache-Control "no-store";
+        add_header X-Frame-Options "SAMEORIGIN";
+        expires    off;
+
+        if (!-f $request_filename) {
+           rewrite ^/static/(version\d*/)?(.*)$ /static.php?resource=$2 last;
+        }
+    }
+    if (!-f $request_filename) {
+        rewrite ^/static/(version\d*/)?(.*)$ /static.php?resource=$2 last;
+    }
+    add_header X-Frame-Options "SAMEORIGIN";
+}
+
+location /media/ {
+
+## The following section allows to offload image resizing from Magento instance to the Nginx.
+## Catalog image URL format should be set accordingly.
+## See https://docs.magento.com/user-guide/configuration/general/web.html#url-options
+#   location ~* ^/media/catalog/.* {
+#
+#       # Replace placeholders and uncomment the line below to serve product images from public S3
+#       # See examples of S3 authentication at https://github.com/anomalizer/ngx_aws_auth
+#       # resolver 8.8.8.8;
+#       # proxy_pass https://<bucket-name>.<region-name>.amazonaws.com;
+#
+#       set $width "-";
+#       set $height "-";
+#       if ($arg_width != '') {
+#           set $width $arg_width;
+#       }
+#       if ($arg_height != '') {
+#           set $height $arg_height;
+#       }
+#       image_filter resize $width $height;
+#       image_filter_jpeg_quality 90;
+#   }
+
+    try_files $uri $uri/ /get.php$is_args$args;
+
+    location ~ ^/media/theme_customization/.*\.xml {
+        deny all;
+    }
+
+    location ~* \.(ico|jpg|jpeg|png|gif|svg|svgz|webp|avif|avifs|js|css|eot|ttf|otf|woff|woff2)$ {
+        add_header Cache-Control "public";
+        add_header X-Frame-Options "SAMEORIGIN";
+        expires +1y;
+        try_files $uri $uri/ /get.php$is_args$args;
+    }
+    location ~* \.(zip|gz|gzip|bz2|csv|xml)$ {
+        add_header Cache-Control "no-store";
+        add_header X-Frame-Options "SAMEORIGIN";
+        expires    off;
+        try_files $uri $uri/ /get.php$is_args$args;
+    }
+    add_header X-Frame-Options "SAMEORIGIN";
+}
+
+#location /media/customer/ {
+#    deny all;
+#}
+
+location /media/downloadable/ {
+    deny all;
+}
+
+location /media/import/ {
+    deny all;
+}
+
+location /media/custom_options/ {
+    deny all;
+}
+
+location /errors/ {
+    location ~* \.xml$ {
+        deny all;
+    }
+}
+
 # PHP entry point for main application
 location ~ ^/(index|get|static|errors/report|errors/404|errors/503|health_check)\.php$ {
     try_files $uri =404;
@@ -17,4 +196,30 @@ location ~ ^/(index|get|static|errors/report|errors/404|errors/503|health_check)
     fastcgi_param MAGE_RUN_CODE $MAGE_RUN_CODE;
     # END - Multisite customization
     include        fastcgi_params;
+}
+
+gzip on;
+gzip_disable "msie6";
+
+gzip_comp_level 6;
+gzip_min_length 1100;
+gzip_buffers 16 8k;
+gzip_proxied any;
+gzip_types
+    text/plain
+    text/css
+    text/js
+    text/xml
+    text/javascript
+    application/javascript
+    application/x-javascript
+    application/json
+    application/xml
+    application/xml+rss
+    image/svg+xml;
+gzip_vary on;
+
+# Banned locations (only reached if the earlier PHP entry point regexes don't match)
+location ~* (\.php$|\.phtml$|\.htaccess$|\.htpasswd$|\.git) {
+    deny all;
 }

--- a/app/magento2/assets/magento-nginx.conf
+++ b/app/magento2/assets/magento-nginx.conf
@@ -15,7 +15,8 @@ server {
     server_name {{ parent().get_service_by_role('magento_front').domain() }}{% for additional_domain in parent().get_service_by_role('magento_front').additional_domains().values() %} {{ additional_domain }}{% endfor %};
     set $MAGE_ROOT {{ get_working_directory() }};
     set $MAGE_RUN_TYPE {{ environment['MAGE_RUN_TYPE'] }};
-    include {{ get_working_directory() }}/nginx.conf.*;
+    include {{ get_working_directory() }}/nginx.conf.riptide;
+    include {{ get_working_directory() }}/nginx.conf.project;
 
     client_max_body_size 100G;
     fastcgi_buffers 16 16k;

--- a/app/magento2/assets/magento-nginx.conf
+++ b/app/magento2/assets/magento-nginx.conf
@@ -1,3 +1,5 @@
+map_hash_bucket_size 128;
+
 upstream fastcgi_backend {
     server php:9000;
 }

--- a/app/magento2/assets/magento-nginx.conf
+++ b/app/magento2/assets/magento-nginx.conf
@@ -2,11 +2,19 @@ upstream fastcgi_backend {
     server php:9000;
 }
 
+map $http_host $MAGE_RUN_CODE {
+    default '';
+    {% for subdomain, additional_domain in parent().get_service_by_role('magento_front').additional_domains().items() %}
+	{{ additional_domain }} {{ environment[(['SUBDOMAIN', (subdomain|upper), 'CODE']|join("_"))] }};
+    {% endfor %}
+}
+
 server {
     listen 80;
 
-    server_name {{ parent().get_service_by_role('magento_front').domain() }};
+    server_name {{ parent().get_service_by_role('magento_front').domain() }}{% for additional_domain in parent().get_service_by_role('magento_front').additional_domains().values() %} {{ additional_domain }}{% endfor %};
     set $MAGE_ROOT {{ get_working_directory() }};
+    set $MAGE_RUN_TYPE {{ environment['MAGE_RUN_TYPE'] }};
     include {{ get_working_directory() }}/nginx.conf.*;
 
     client_max_body_size 100G;

--- a/app/magento2/assets/magento-nginx.conf
+++ b/app/magento2/assets/magento-nginx.conf
@@ -18,7 +18,8 @@ server {
     set $MAGE_ROOT {{ get_working_directory() }};
     set $MAGE_RUN_TYPE {{ environment['MAGE_RUN_TYPE'] }};
     include {{ get_working_directory() }}/nginx.conf.riptide;
-    include {{ get_working_directory() }}/nginx.conf.project;
+    # The [.] turns it into a glob pattern and makes the include optional essentially.
+    include {{ get_working_directory() }}/nginx.conf[.]project;
 
     client_max_body_size 100G;
     fastcgi_buffers 16 16k;

--- a/app/magento2/base.yml
+++ b/app/magento2/base.yml
@@ -88,13 +88,11 @@ app:
       config:
         nginx_conf_main_entry:
           from: assets/magento-nginx-entrypoint.conf
-          to: '{{ get_working_directory() }}/nginx.conf.main_entry'
+          to: '{{ get_working_directory() }}/nginx.conf.riptide'
         env_php:
           from: assets/env.php
           to: '{{ get_working_directory() }}/app/etc/env.php'
       pre_start:
-        # Remove main entrypoint from nginx.conf.sample
-        - "sed -i'' -z -E 's/# PHP entry point for main application(\n|.)*}\n\n//' '{{ get_working_directory() }}/nginx.conf.sample'"
         # Wait for db
         - 'until bin/magento; do :; done'
         # Set basic database settings

--- a/app/magento2/base.yml
+++ b/app/magento2/base.yml
@@ -28,7 +28,7 @@ app:
         # 0. Download the Magento source code (replace with 'enterprise-edition' if you want):
         mkdir -p <project_directory_root>/{{ parent().src }}
         cd <project_directory_root>/{{ parent().src }}
-        riptide cmd composer create-project --repository=https://repo.magento.com magento/project-community-edition ./{{ services.php.working_directory }}
+        riptide cmd composer create-project --repository=https://repo.magento.com magento/project-community-edition ./{{ services.php.working_directory }} "2.3.*"
 
         # 1. Dump the autoloader
         cd ./{{ services.php.working_directory }}

--- a/app/magento2/base.yml
+++ b/app/magento2/base.yml
@@ -19,6 +19,14 @@ app:
         riptide cmd magento setup:upgrade
 
       Riptide set's only the default store's Base URLs (to http://{{ get_service_by_role("magento_front").domain() }}).
+      
+      Optional:
+        If you want to configure multiple websites you need to specify additional_subdomains for the service '{{ get_service_by_role("src")["$name"] }}'
+        and add the subdomain of every website (except the default one) to the list.
+        Additionally you'll need to set the MAGE_RUN_CODE for every website,
+        which is done by setting an environment variable for each subdomain you added using the following key: SUBDOMAIN_<uppercase subdomain name>_CODE
+      
+        You can find an example configuration here: 
 
       After that your Magento shop will be ready! Enjoy!
 
@@ -54,10 +62,10 @@ app:
           --timezone=America/Chicago \
           --use-rewrites=1
 
-        # 3. (Optional) install sample data
+        # 4. (Optional) install sample data
         riptide cmd magento sampledata:deploy
 
-        # 4. Run setup:upgrade
+        # 5. Run setup:upgrade
         riptide restart -s redis
         riptide cmd magento setup:upgrade
 
@@ -78,10 +86,15 @@ app:
         stdout: true
         stderr: true
       config:
+        nginx_conf_main_entry:
+          from: assets/magento-nginx-entrypoint.conf
+          to: '{{ get_working_directory() }}/nginx.conf.main_entry'
         env_php:
           from: assets/env.php
           to: '{{ get_working_directory() }}/app/etc/env.php'
       pre_start:
+        # Remove main entrypoint from nginx.conf.sample
+        - "sed -i'' -z -E 's/# PHP entry point for main application(\n|.)*}\n\n//' '{{ get_working_directory() }}/nginx.conf.sample'"
         # Wait for db
         - 'until bin/magento; do :; done'
         # Set basic database settings
@@ -102,6 +115,8 @@ app:
       logging:
         stdout: true
         stderr: true
+      environment:
+        MAGE_RUN_TYPE: website
       config:
         env_php:
           from: assets/env.php

--- a/app/magento2/base.yml
+++ b/app/magento2/base.yml
@@ -132,6 +132,7 @@ app:
 
     db:
       $ref: /service/mysql/5.7
+      image: mariadb:10.6
       driver:
         config:
           database: magento2

--- a/app/magento2/base.yml
+++ b/app/magento2/base.yml
@@ -26,7 +26,7 @@ app:
         Additionally you'll need to set the MAGE_RUN_CODE for every website,
         which is done by setting an environment variable for each subdomain you added using the following key: SUBDOMAIN_<uppercase subdomain name>_CODE
       
-        You can find an example configuration here: 
+        You can find an example configuration here: https://github.com/theCapypara/riptide-repo/pull/28#Example
 
       After that your Magento shop will be ready! Enjoy!
 

--- a/app/magento2/ce/2.4.yml
+++ b/app/magento2/ce/2.4.yml
@@ -51,6 +51,14 @@ app:
         # 5. Run setup:upgrade
         riptide restart -s redis
         riptide cmd magento setup:upgrade
+      
+      Optional:
+        If you want to configure multiple websites you need to specify additional_subdomains for the service '{{ get_service_by_role("src")["$name"] }}'
+        and add the subdomain of every website (except the default one) to the list.
+        Additionally you'll need to set the MAGE_RUN_CODE for every website,
+        which is done by setting an environment variable for each subdomain you added using the following key: SUBDOMAIN_<uppercase subdomain name>_CODE
+  
+        You can find an example configuration here: 
 
       You can change the settings in step 3 to your likings, see the installation guide at
         https://devdocs.magento.com/guides/v2.4/install-gde/install/cli/install-cli.html

--- a/app/magento2/ce/2.4.yml
+++ b/app/magento2/ce/2.4.yml
@@ -61,3 +61,5 @@ app:
       config:
         env_php:
           from: assets/2.4/env.php
+    db:
+      image: mariadb:10.6

--- a/app/magento2/ce/2.4.yml
+++ b/app/magento2/ce/2.4.yml
@@ -58,7 +58,7 @@ app:
         Additionally you'll need to set the MAGE_RUN_CODE for every website,
         which is done by setting an environment variable for each subdomain you added using the following key: SUBDOMAIN_<uppercase subdomain name>_CODE
   
-        You can find an example configuration here: 
+        You can find an example configuration here: https://github.com/theCapypara/riptide-repo/pull/28#Example
 
       You can change the settings in step 3 to your likings, see the installation guide at
         https://devdocs.magento.com/guides/v2.4/install-gde/install/cli/install-cli.html

--- a/app/magento2/ce/2.4.yml
+++ b/app/magento2/ce/2.4.yml
@@ -57,6 +57,7 @@ app:
 
   services:
     php:
+      image: riptidepy/php:8.1-fpm
       config:
         env_php:
           from: assets/2.4/env.php

--- a/app/magento2/ce/2.4.yml
+++ b/app/magento2/ce/2.4.yml
@@ -61,5 +61,3 @@ app:
       config:
         env_php:
           from: assets/2.4/env.php
-    db:
-      image: mariadb:10.6


### PR DESCRIPTION
This PR makes a few changes to the existing Magento2 app.

## General fixes

- Magento 2.3 now creates projects with the correct version again.
- Magento 2.3 and 2.4 can be installed correctly again by changing the db image to [mariadb](https://hub.docker.com/_/mariadb/) 10.6 (which is the latest version supported by Magento at the time).
- Additionally Magento 2.4 requires a newer php version, so the image version was updated to 8.1-fpm as well.

## Multisite configuration

Magento is able to [host multiple websites and stores](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/multi-sites/ms-nginx.html), but until now there was no easy way to access them using riptide.

By replacing the main entrypoint of `nginx.conf.sample` with a slightly customized one and adding a few options to the default nginx configuration `magento-nginx.conf`, you are now able to use riptide's project configuration to add multiple websites/stores for Magento and expose them on different subdomains.

### Example

<details>
<summary>Magento 2.4 riptide config</summary>

```yml
project:
  name: magento-demo-2-4
  src: src
  app:
    $ref: /app/magento2/ce/2.4
    services:
      www:
        environment:
          SUBDOMAIN_TEST1_CODE: test
          SUBDOMAIN_TEST2_CODE: test2
          SUBDOMAIN_TEST3_CODE: test3
      varnish:
        additional_subdomains:
          - test1
          - test2
          - test3
```
</details> 

### Configuration

1. Add the new subdomains to the service with the main role (in this case `varnish`) using the key `additional_subdomains`.
2. Add the `MAGE_RUN_CODE` for every website as an environment variable to the `www` service using the following key: `SUBDOMAIN_{ additional subdomain (uppercase) }_CODE`.
3. If you want to change the `MAGE_RUN_TYPE` you can do this by setting the environment variable (also named: `MAGE_RUN_TYPE`) to a different value for the `www` service. (Default: `website`)

---

Depends on: theCapypara/riptide-lib#45