### PR TITLE
[Hotfix] magento2: Downgrade MariaDB to 10.4

### DIFF
--- a/app/magento2/base.yml
+++ b/app/magento2/base.yml
@@ -148,7 +148,7 @@ app:
 
     db:
       $ref: /service/mysql/5.7
-      image: mariadb:10.6
+      image: mariadb:10.4
       driver:
         config:
           database: magento2


### PR DESCRIPTION
With the last PR we also updated the MariaDB version that's used by Magento2. Although `10.6` is an LTS version, Magento2 still doesn't support either `10.5` or `10.6`.

This was noticed by @hsm00 as he tried to perform a `magento setup:upgrade`

```
Current version of RDBMS is not supported. Used Version: 10.6.14-MariaDB-1:10.6.14+maria~ubu2004. Supported versions: MySQL-8, MySQL-5.7, MariaDB-(10.2-10.4)
```

So the only choice we have for now is to downgrade to MariaDB `10.4`.