### PR TITLE
Update OpenSearch service and provide multiple versions

### DIFF
--- a/service/opensearch/1.yml
+++ b/service/opensearch/1.yml
@@ -1,0 +1,3 @@
+service:
+  $ref: ./latest
+  image: riptidepy/opensearch:1

--- a/service/opensearch/2.yml
+++ b/service/opensearch/2.yml
@@ -1,0 +1,3 @@
+service:
+  $ref: ./latest
+  image: riptidepy/opensearch:2

--- a/service/opensearch/README.rst
+++ b/service/opensearch/README.rst
@@ -20,6 +20,24 @@ The template provided is tested for OpenSearch 1.2.0.
 
 **Runs as the user using Riptide?**: yes
 
-**Accessible via Proxy?**: no
+**Accessible via Proxy?**: yes
 
 Latest version of OpenSearch.
+
+``/service/opensearch/1``
+---------------------------------
+
+**Runs as the user using Riptide?**: yes
+
+**Accessible via Proxy?**: yes
+
+Version 1 of OpenSearch.
+
+``/service/opensearch/2``
+---------------------------------
+
+**Runs as the user using Riptide?**: yes
+
+**Accessible via Proxy?**: yes
+
+Version 2 of OpenSearch.

--- a/service/opensearch/assets/opensearch.yml
+++ b/service/opensearch/assets/opensearch.yml
@@ -1,4 +1,5 @@
 cluster.name: riptide-cluster
+bootstrap.memory_lock: true
 
 # Bind to all interfaces because we don't know what IP address Docker will assign to us.
 network.host: 0.0.0.0
@@ -9,3 +10,6 @@ node.name: riptide
 
 action.auto_create_index: true
 compatibility.override_main_response_version: true
+
+# Prevent OpenSearch from setting read-only mode on "low" storage space
+cluster.routing.allocation.disk.threshold_enabled: false

--- a/service/opensearch/latest.yml
+++ b/service/opensearch/latest.yml
@@ -1,11 +1,7 @@
 service:
-  # WARNING: Under Linux make sure to run "sudo sysctl -w vm.max_map_count=262144" before or ES will crash.
-  image: opensearch:latest
+  # WARNING: Under Linux make sure to run "sudo sysctl -w vm.max_map_count=262144" before or OS will crash.
+  image: riptidepy/opensearch:latest
   environment:
-    node.name: riptide
-    cluster.name: riptide-cluster
-    bootstrap: memory_lock=true
-    discovery.type: "single-node"
     ES_JAVA_OPTS: "-Xms512m -Xmx512m -Dlog4j2.formatMsgNoLookups=true"
   port: 9200
   additional_volumes:
@@ -15,9 +11,8 @@ service:
   logging:
     stdout: true
     stderr: true
-  run_as_current_user: false
   pre_start:
-    - chown -R 1000:1000 /usr/share/opensearch/data
+    - "chown -R {{ os_user() }}:{{ os_group() }} /usr/share/opensearch/data"
   config:
     opensearchyaml:
       from: assets/opensearch.yml


### PR DESCRIPTION
This PR updates the service configuration for OpenSearch and introduces variants for the different versions of the official images.

I have previously encountered issues where OpenSearch would enter read-only mode even though I had more than enough storage for what I was doing with it. That's why I have disabled this behavior with a setting in the config file. 

---

Depends on https://github.com/theCapypara/riptide-docker-images/pull/20