### PR TITLE
Allow Jetbrains IDEs to use php command

### DIFF
--- a/command/php/base.yml
+++ b/command/php/base.yml
@@ -8,3 +8,6 @@ command:
         host: "~/.cache/riptide/{{ parent().parent().name }}/{{ image }}/opcache/xdebug_{% if system_config().get_plugin_flag('php-xdebug.enabled') %}en{% else %}dis{% endif %}abled"
         container: "/opcache"
         volume_name: "php_opcache__{{ parent().parent().name }}__{{ image | replace(':', '_') | replace('/', '_') }}__xdebug_{% if system_config().get_plugin_flag('php-xdebug.enabled') %}enabled{% else %}disabled{% endif %}"
+      tmp_phpinfo:
+        host: "/tmp/ide-phpinfo.php"
+        container: "/tmp/ide-phpinfo.php"

--- a/command/php/base.yml
+++ b/command/php/base.yml
@@ -9,5 +9,5 @@ command:
         container: "/opcache"
         volume_name: "php_opcache__{{ parent().parent().name }}__{{ image | replace(':', '_') | replace('/', '_') }}__xdebug_{% if system_config().get_plugin_flag('php-xdebug.enabled') %}enabled{% else %}disabled{% endif %}"
       tmp_phpinfo:
-        host: "/tmp/ide-phpinfo.php"
-        container: "/tmp/ide-phpinfo.php"
+        host: "{{ get_tempdir() }}/ide-phpinfo.php"
+        container: "{{ get_tempdir() }}/ide-phpinfo.php"


### PR DESCRIPTION
This PR adds an additional volume to the php command, so that Jetbrains IDEs can use the php bin provided by riptide as an interpreter.

<img width="1222" height="685" alt="image" src="https://github.com/user-attachments/assets/2264edcb-8733-4719-a020-c08f35205f63" />

I prefer this to adding the Docker image as an interpreter, since I don't need to look up which image is used by riptide first.