### PR TITLE
Switch to official images where custom ones are not needed anymore

### DIFF
--- a/service/mysql/8.4.yml
+++ b/service/mysql/8.4.yml
@@ -1,3 +1,3 @@
 service:
   $ref: ./base
-  image: riptidepy/mysql:8.4
+  image: mysql:8.4-oracle

--- a/service/opensearch/1.yml
+++ b/service/opensearch/1.yml
@@ -1,3 +1,3 @@
 service:
   $ref: ./latest
-  image: riptidepy/opensearch:1
+  image: opensearchproject/opensearch:1

--- a/service/opensearch/2.yml
+++ b/service/opensearch/2.yml
@@ -1,3 +1,3 @@
 service:
   $ref: ./latest
-  image: riptidepy/opensearch:2
+  image: opensearchproject/opensearch:2

--- a/service/opensearch/latest.yml
+++ b/service/opensearch/latest.yml
@@ -1,6 +1,6 @@
 service:
   # WARNING: Under Linux make sure to run "sudo sysctl -w vm.max_map_count=262144" before or OS will crash.
-  image: riptidepy/opensearch:latest
+  image: opensearchproject/opensearch
   environment:
     ES_JAVA_OPTS: "-Xms512m -Xmx512m -Dlog4j2.formatMsgNoLookups=true"
   port: 9200


### PR DESCRIPTION
This replaces images that were [replaced](https://github.com/theCapypara/riptide-docker-images/pull/30) with their official images.

NOTE: This is not compatible with Riptide <= 0.9. **Before** merging this the branch `0.9` must be set to the current commit on master.